### PR TITLE
Support listen UNIX addr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Gas aims to be a high performance, full-featured, easy to use, and quick develop
 - Logger package [gas-logger](https://github.com/go-gas/logger)
 - Read config from a yaml file [gas-config](https://github.com/go-gas/config)
 - Database model (developing, based on [go-gas/SQLBuilder](https://github.com/go-gas/SQLBuilder))
-- HTTP/HTTPS Protocol.
+- Support listen HTTP/HTTPS and UNIX addr.
 
 other features are highly active development
 
@@ -296,16 +296,22 @@ Run and listen your web application with default `8080` port.
 g.Run()
 ```
 
-or you can give listen address and another port.
+you can give listen address and another port.
 
 ```go
 g.Run(":8089")
 ```
 
-or serving HTTPS (secure) requests.
+Serving HTTPS (secure) requests.
 
 ```go
 g.RunTLS(":8080", "CertFile", "CertKey")
+```
+
+HTTP requests from the given UNIX addr.
+
+```go
+g.RunUNIX("/tmp/gas.sock", 0644)
 ```
 
 but I recommend setting listen address in config files.

--- a/gas.go
+++ b/gas.go
@@ -256,6 +256,16 @@ func (g *Engine) RunTLS(addr ...string) (err error) {
 	return
 }
 
+// RunUNIX serves HTTP requests from the given UNIX addr.
+//
+// The function deletes existing file at addr before starting serving.
+// The server sets the given file mode for the UNIX addr.
+func (g *Engine) RunUNIX(addr string, mode os.FileMode) (err error) {
+
+	err = fasthttp.ListenAndServeUNIX(addr, mode, g.Router.Handler)
+	return
+}
+
 func Logger(next GasHandler) GasHandler {
 	return func(c *Context) error {
 		l := logger.New("log/logs.txt")

--- a/gas_test.go
+++ b/gas_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/valyala/fasthttp"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 )
@@ -164,6 +165,22 @@ func TestRunTLSWithConfig(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 
 	testRequest(t, "https://localhost:8089")
+}
+
+func TestRunUNIX(t *testing.T) {
+	g := New()
+
+	// set route
+	g.Router.Get("/", indexPage)
+
+	go func() {
+		assert.NoError(t, g.RunUNIX("gas.sock", 0644))
+	}()
+	time.Sleep(5 * time.Millisecond)
+
+	_, err := os.Stat("gas.sock")
+
+	assert.False(t, os.IsNotExist(err))
 }
 
 func TestGas_NewModel(t *testing.T) {


### PR DESCRIPTION
`RunUNIX` serves HTTP requests from the given UNIX addr.
The function deletes existing file at addr before starting serving.
The server sets the given file mode for the UNIX addr.

Fixed #15 

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>